### PR TITLE
Preserve grid scroll position

### DIFF
--- a/dist/fast-search-card.js
+++ b/dist/fast-search-card.js
@@ -2,6 +2,7 @@ class FastSearchCard extends HTMLElement {
     constructor() {
         super();
         this.attachShadow({ mode: 'open' });
+        this.gridScrollPositions = {};
     }
 
     setConfig(config) {
@@ -20,6 +21,7 @@ class FastSearchCard extends HTMLElement {
 
     set hass(hass) {
         this._hass = hass;
+        this.storeGridScrollPositions();
         this.updateItems();
     }
 
@@ -699,6 +701,7 @@ class FastSearchCard extends HTMLElement {
         this.selectedRooms.clear();
         this.selectedType = '';
         this.updateSearchUI();
+        this.storeGridScrollPositions();
         this.updateItems();
     }
 
@@ -716,14 +719,25 @@ class FastSearchCard extends HTMLElement {
 
     switchView(view) {
         this.currentView = view;
-        
+
         // Update button states
         this.shadowRoot.querySelectorAll('.view-button').forEach(btn => {
             btn.classList.toggle('active', btn.dataset.view === view);
         });
-        
+
         // Re-render current results
         this.applyFilters();
+    }
+
+    storeGridScrollPositions() {
+        this.gridScrollPositions = {};
+        if (!this.shadowRoot) return;
+        this.shadowRoot.querySelectorAll('.grid-items').forEach(el => {
+            const room = el.dataset.room;
+            if (room) {
+                this.gridScrollPositions[room] = el.scrollLeft;
+            }
+        });
     }
 
     updateItems() {
@@ -1161,6 +1175,7 @@ class FastSearchCard extends HTMLElement {
             
             const gridItems = document.createElement('div');
             gridItems.className = 'grid-items';
+            gridItems.dataset.room = room;
 
             itemsByRoom[room].forEach(item => {
                 const gridItem = this.createGridItem(item);
@@ -1168,6 +1183,9 @@ class FastSearchCard extends HTMLElement {
             });
 
             roomSection.appendChild(gridItems);
+            if (this.gridScrollPositions && this.gridScrollPositions[room]) {
+                gridItems.scrollLeft = this.gridScrollPositions[room];
+            }
             gridContainer.appendChild(roomSection);
         });
         


### PR DESCRIPTION
## Summary
- remember scroll positions of grid lists before item updates
- restore scroll positions after rendering

## Testing
- `node -e "require('./dist/fast-search-card.js');"` *(fails: HTMLElement is not defined)*